### PR TITLE
add support for Storybook module mocking

### DIFF
--- a/packages/vitest-plugin-storybook/src/plugin.ts
+++ b/packages/vitest-plugin-storybook/src/plugin.ts
@@ -65,6 +65,10 @@ export const storybookTest = (options?: UserOptions): any => {
         'import.meta.env.__STORYBOOK_URL__': JSON.stringify(storybookUrl),
       }
 
+      config.resolve = config.resolve ?? {}
+      config.resolve.conditions = config.resolve.conditions ?? []
+      config.resolve.conditions.push('storybook', 'stories', 'test')
+
       config.test.setupFiles = config.test.setupFiles ?? []
       if (typeof config.test.setupFiles === 'string') {
         config.test.setupFiles = [config.test.setupFiles]

--- a/test/package.json
+++ b/test/package.json
@@ -31,5 +31,11 @@
     "vite-plugin-inspect": "^0.8.4",
     "vitest": "^2.0.4",
     "webdriverio": "^8.36.1"
+  },
+  "imports": {
+    "#utils": {
+      "storybook": "./src/utils.mock.ts",
+      "default": "./src/utils.ts"
+    }
   }
 }

--- a/test/src/Button.stories.tsx
+++ b/test/src/Button.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
-import { expect, within } from '@storybook/test'
+import { expect, isMockFunction, mocked, within } from '@storybook/test'
+import { foo } from '#utils'
 
 import { Button } from './Button'
 
@@ -45,6 +46,17 @@ export const Secondary: Story = {
 export const Skipped: Story = {
   ...Primary,
   tags: ['!test'],
+}
+
+export const ModuleMocking: Story = {
+  ...Primary,
+  beforeEach: () => {
+    mocked(foo).mockReturnValue('mocked')
+  },
+  async play() {
+    await expect(isMockFunction(foo)).toBe(true)
+    await expect(foo()).toBe('mocked')
+  },
 }
 
 const ResponsiveComponent = () => {

--- a/test/src/utils.mock.ts
+++ b/test/src/utils.mock.ts
@@ -1,0 +1,4 @@
+import { fn } from '@storybook/test'
+import * as utils from './utils.ts'
+
+export const foo = fn(utils.foo).mockName('foo')

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -1,0 +1,1 @@
+export const foo = () => 'not mocked'


### PR DESCRIPTION
Closes #https://github.com/storybookjs/storybook/issues/28744
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.1--canary.3.7cd9faa.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/experimental-vitest-plugin@0.0.1--canary.3.7cd9faa.0
  # or 
  yarn add @storybook/experimental-vitest-plugin@0.0.1--canary.3.7cd9faa.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
