### PR TITLE
Make the plugin renderer agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,8 @@ The Storybook Vitest plugin transforms story files into test files using the por
 
 This is a Vitest plugin, so you have to have Vitest set up in your project. It relies on testing-library, so you must also have it set up in your project.
 
-## Renderer support
-
-Currently this solution supports the following renderers:
-- React
-- Vue3
-- Svelte
+> [!IMPORTANT]
+> If you are using Next.js, you have to use this plugin in tandem with [vite-plugin-storybook-nextjs](https://github.com/storybookjs/vite-plugin-storybook-nextjs).
 
 ## Getting started
 
@@ -39,7 +35,7 @@ export default mergeConfig(
   defineConfig({
     plugins: [
       storybookTest({
-        renderer: 'react',
+        storybookScript: 'yarn storybook',
       }),
     ],
     test: {
@@ -104,15 +100,6 @@ The plugin should work out of the box, but there are extra functionalities if yo
 - **Description:** Whether to skip running Storybook when running tests in watch mode. This option is only relevant when `storybookScript` is provided.
 - **Default:** `false`
 
-### `renderer`
-
-- **Type:** `react | vue | svelte | nextjs`
-- **Description:** The renderer used by Storybook.
-- **Default:** `undefined`
-
-> [!IMPORTANT]
-> If you are using Next.js, you have to use this plugin in tandem with [vite-plugin-storybook-nextjs](https://github.com/storybookjs/vite-plugin-storybook-nextjs).
-
 ### `snapshot`
 
 - **Type:** `boolean`
@@ -137,8 +124,6 @@ The plugin should work out of the box, but there are extra functionalities if yo
 
 ```ts
 storybookTest({
-  // API options here
-  renderer: 'react',
   // Make sure to pass the --ci flag so Storybook won't pop up the browser
   storybookScript: 'npm run storybook -- --ci',
 });

--- a/packages/vitest-plugin-storybook/package.json
+++ b/packages/vitest-plugin-storybook/package.json
@@ -54,7 +54,8 @@
     "vitest": "^2.0.0"
   },
   "peerDependencies": {
-    "vitest": "^2.0.0"
+    "vitest": "^2.0.0",
+    "storybook": "^8.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vitest-plugin-storybook/src/plugin.ts
+++ b/packages/vitest-plugin-storybook/src/plugin.ts
@@ -11,7 +11,6 @@ const require = createRequire(import.meta.url)
 
 const defaultOptions: UserOptions = {
   storybookScript: undefined,
-  renderer: undefined,
   configDir: undefined,
   storybookUrl: 'http://localhost:6006',
   snapshot: false,

--- a/packages/vitest-plugin-storybook/src/transformer.ts
+++ b/packages/vitest-plugin-storybook/src/transformer.ts
@@ -2,7 +2,6 @@ import MagicString from 'magic-string'
 import typescript from 'typescript'
 import dedent from 'ts-dedent'
 import type { InternalOptions } from './types'
-import { PACKAGES_MAP } from './utils'
 
 // Main transform function for the Vitest plugin
 export async function transform({
@@ -143,12 +142,11 @@ export async function transform({
 
   typescript.forEachChild(sourceFile, modifyStories)
 
-  const metadata = PACKAGES_MAP[options.renderer]
   // Add necessary imports to the transformed file
   s.append(
     dedent`\n
       import { test as __test } from 'vitest';
-      import { composeStories as __composeStories } from '${metadata.storybookPackage}';
+      import { composeStories as __composeStories } from 'storybook/internal/preview-api';
       import { testStory as __testStory } from '@storybook/experimental-vitest-plugin/dist/test-utils';
     `
   )

--- a/packages/vitest-plugin-storybook/src/types.ts
+++ b/packages/vitest-plugin-storybook/src/types.ts
@@ -1,5 +1,3 @@
-export type SupportedRenderers = 'react' | 'vue3' | 'svelte' | 'nextjs'
-
 export type UserOptions = {
   /**
    *  The directory where the Storybook configuration is located, relative to the vitest configuration file.
@@ -19,11 +17,6 @@ export type UserOptions = {
    *  @default false
    */
   skipRunningStorybook?: boolean
-  /**
-   *  The renderer used by Storybook. If not provided, it will be inferred from the main config file located in the `configDir`.
-   *  @default undefined
-   */
-  renderer?: SupportedRenderers
   /**
    *  Whether to generate DOM snapshots for every story file.
    *  @default false

--- a/packages/vitest-plugin-storybook/src/utils.ts
+++ b/packages/vitest-plugin-storybook/src/utils.ts
@@ -1,24 +1,3 @@
-import type { SupportedRenderers } from './types'
-
-type RendererSpecificTemplates = {
-  storybookPackage: string
-}
-
-export const PACKAGES_MAP = {
-  nextjs: {
-    storybookPackage: '@storybook/nextjs',
-  },
-  react: {
-    storybookPackage: '@storybook/react',
-  },
-  vue3: {
-    storybookPackage: '@storybook/vue3',
-  },
-  svelte: {
-    storybookPackage: '@storybook/svelte',
-  },
-} satisfies Record<SupportedRenderers, RendererSpecificTemplates>
-
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
 export const log = (...args: any) => {
   if (process.env.DEBUG || process.env.DEBUG === 'storybook') {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       magic-string:
         specifier: ^0.30.10
         version: 0.30.10
+      storybook:
+        specifier: ^8.2.0
+        version: 8.2.7(@babel/preset-env@7.24.6(@babel/core@7.24.6))
       typescript:
         specifier: ^5.0.0
         version: 5.0.2
@@ -1510,6 +1513,9 @@ packages:
   '@storybook/client-logger@8.1.5':
     resolution: {integrity: sha512-zd+aENXnOHsxBATppELmhw/UywLzCxQjz/8i/xkUjeTRB4Ggp0hJlOUdJUEdIJz631ydyytfvM70ktBj9gMl1w==}
 
+  '@storybook/codemod@8.2.7':
+    resolution: {integrity: sha512-D2sJcZMUO6Y7DNja4LvdT6uBee4bZbQKB904kEG9Kpr0XF20IHAP9BbkfG8HEFaS0GbJwvGvE03Sg+S1y+vO6Q==}
+
   '@storybook/codemod@8.3.0-alpha.3':
     resolution: {integrity: sha512-3kEj/7VDEXprSeayfNjkRRJmx90OpLMraL6xZvrmvcOh0RQzGrcSu87nc+RULvVW6Au1FDKIROWK3QwSv776BQ==}
 
@@ -1528,6 +1534,9 @@ packages:
 
   '@storybook/core-events@8.1.5':
     resolution: {integrity: sha512-fgwbrHoLtSX6kfmamTGJqD+KfuEgun8cc4mWKZK094ByaqbSjhnOyeYO1sfVk8qst7QTFlOfhLAUe4cz1z149A==}
+
+  '@storybook/core@8.2.7':
+    resolution: {integrity: sha512-vgw5MYN9Bq2/ZsObCOEHbBHwi4RpbYCHPFtKkr4kTnWID++FCSiSVd7jY3xPvcNxWqCxOyH6dThpBi+SsB/ZAA==}
 
   '@storybook/core@8.3.0-alpha.3':
     resolution: {integrity: sha512-QiataROyfX0d8/ztRd1rnb7vB+n0RbosJsiw5Ltng+nF2ZSpMWAI8C7A48vl8yu3DRJSQ1WjWd0vzCAOBcVo6Q==}
@@ -4586,6 +4595,10 @@ packages:
   std-env@3.7.0:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
 
+  storybook@8.2.7:
+    resolution: {integrity: sha512-Jb9DXue1sr3tKkpuq66VP5ItOKTpxL6t99ze1wXDbjCvPiInTdPA5AyFEjBuKjOBIh28bayYoOZa6/xbMJV+Wg==}
+    hasBin: true
+
   storybook@8.3.0-alpha.3:
     resolution: {integrity: sha512-nwZJdK1wNmHsmCB2eJYg3kiGX9X3IEG/e5+9HRsgrwl9TPohKe3cOm1Br9QoJceWGz4sOCwRZe60IlOD7b0bhQ==}
     hasBin: true
@@ -6816,6 +6829,26 @@ snapshots:
     dependencies:
       '@storybook/global': 5.0.0
 
+  '@storybook/codemod@8.2.7':
+    dependencies:
+      '@babel/core': 7.24.6
+      '@babel/preset-env': 7.24.6(@babel/core@7.24.6)
+      '@babel/types': 7.24.6
+      '@storybook/core': 8.2.7
+      '@storybook/csf': 0.1.11
+      '@types/cross-spawn': 6.0.6
+      cross-spawn: 7.0.3
+      globby: 14.0.1
+      jscodeshift: 0.15.2(@babel/preset-env@7.24.6(@babel/core@7.24.6))
+      lodash: 4.17.21
+      prettier: 3.2.5
+      recast: 0.23.6
+      tiny-invariant: 1.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@storybook/codemod@8.3.0-alpha.3':
     dependencies:
       '@babel/core': 7.24.6
@@ -6881,6 +6914,24 @@ snapshots:
     dependencies:
       '@storybook/csf': 0.1.11
       ts-dedent: 2.2.0
+
+  '@storybook/core@8.2.7':
+    dependencies:
+      '@storybook/csf': 0.1.11
+      '@types/express': 4.17.21
+      '@types/node': 18.19.33
+      browser-assert: 1.2.1
+      esbuild: 0.20.2
+      esbuild-register: 3.5.0(esbuild@0.20.2)
+      express: 4.19.2
+      process: 0.11.10
+      recast: 0.23.6
+      util: 0.12.5
+      ws: 8.18.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   '@storybook/core@8.3.0-alpha.3':
     dependencies:
@@ -10216,6 +10267,42 @@ snapshots:
   statuses@2.0.1: {}
 
   std-env@3.7.0: {}
+
+  storybook@8.2.7(@babel/preset-env@7.24.6(@babel/core@7.24.6)):
+    dependencies:
+      '@babel/core': 7.24.6
+      '@babel/types': 7.24.6
+      '@storybook/codemod': 8.2.7
+      '@storybook/core': 8.2.7
+      '@types/semver': 7.5.8
+      '@yarnpkg/fslib': 2.10.3
+      '@yarnpkg/libzip': 2.3.0
+      chalk: 4.1.2
+      commander: 6.2.1
+      cross-spawn: 7.0.3
+      detect-indent: 6.1.0
+      envinfo: 7.13.0
+      execa: 5.1.1
+      fd-package-json: 1.2.0
+      find-up: 5.0.0
+      fs-extra: 11.2.0
+      giget: 1.2.3
+      globby: 14.0.1
+      jscodeshift: 0.15.2(@babel/preset-env@7.24.6(@babel/core@7.24.6))
+      leven: 3.1.0
+      ora: 5.4.1
+      prettier: 3.2.5
+      prompts: 2.4.2
+      semver: 7.6.1
+      strip-json-comments: 3.1.1
+      tempy: 3.1.0
+      tiny-invariant: 1.3.3
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   storybook@8.3.0-alpha.3(@babel/preset-env@7.24.6(@babel/core@7.24.6)):
     dependencies:

--- a/test/.storybook/vitest.config.ts
+++ b/test/.storybook/vitest.config.ts
@@ -8,7 +8,6 @@ export default mergeConfig(
   defineConfig({
     plugins: [
       storybookTest({
-        renderer: 'react',
         storybookScript: 'pnpm run storybook --ci',
       }),
       Inspect({ build: true, outputDir: '.vite-inspect' }),


### PR DESCRIPTION
This PR will need a canary release from Storybook, tests are expected to fail
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.5--canary.6.bbeaab3.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/experimental-vitest-plugin@0.0.5--canary.6.bbeaab3.0
  # or 
  yarn add @storybook/experimental-vitest-plugin@0.0.5--canary.6.bbeaab3.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
